### PR TITLE
Cleanup and license

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 module.exports = {
   env: {
     node: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,7 @@
+# Copyright 2024 Digital Bazaar, Inc.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 name: Generate Interop Report
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Copyright 2024 Digital Bazaar, Inc.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 *.sw[nop]
 *.py[co]
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<!--
+Copyright 2024 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 # w3c/vc-di-bbs-test-suite  ChangeLog
 
 ## 1.1.0 - 2023-12-14

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2023-2024, World Wide Web Consortium
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,11 @@
+Copyright (c) <year> <owner>. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Provides interoperability tests for verifiable credential processors
 
 ## Install
 
-```js
+```sh
 npm i
 ```
 
 ## Usage
 
-```
+```sh
 npm test
 ```
 
@@ -48,7 +48,7 @@ All endpoints will require a cryptosuite tag of `bbs-2023`.
 
 A simplified manifest would look like this:
 
-```js
+```json
 {
   "name": "My Company",
   "implementation": "My implementation",

--- a/README.md
+++ b/README.md
@@ -86,4 +86,4 @@ Pull Requests are welcome!
 
 ## License
 
-See [the LICENSE.md file](LICENSE.md)
+See [the LICENSE file](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
+<!--
+Copyright 2024 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 # [BBS](https://www.w3.org/TR/vc-di-bbs/) Cryptosuite test suite
 
 ## Table of Contents
 
-- [BBS Cryptosuite test suite](#bbs-cryptosuite-test-suite)
-  - [Table of Contents](#table-of-contents)
-  - [Background](#background)
-  - [Install](#install)
-  - [Usage](#usage)
-  - [Implementation](#implementation)
-    - [Docker Integration (TODO)](#docker-integration-todo)
-  - [Contribute](#contribute)
-  - [License](#license)
+- [Background](#background)
+- [Install](#install)
+- [Usage](#usage)
+- [Implementation](#implementation)
+  - [Docker Integration (TODO)](#docker-integration-todo)
+- [Contribute](#contribute)
+- [License](#license)
 
 ## Background
 Provides interoperability tests for verifiable credential processors

--- a/abstract.hbs
+++ b/abstract.hbs
@@ -1,3 +1,9 @@
+{{!--
+Copyright 2024 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: BSD-3-Clause
+--}}
+
 <section id="abstract">
   <p>
   The purpose of this test suite is to demonstrate a path to interoperability

--- a/package.json
+++ b/package.json
@@ -11,11 +11,19 @@
     "test": "mocha tests/ --reporter @digitalbazaar/mocha-w3c-interop-reporter --reporter-options abstract=\"$PWD/abstract.hbs\",reportDir=\"$PWD/reports\",respec=\"$PWD/respecConfig.json\",suiteLog='./suite.log',templateData=\"$PWD/reports/index.json\",title=\"Data Integrity BBS Interoperability Report 1.0\" --timeout 15000 --preserve-symlinks",
     "lint": "eslint ."
   },
+  "license": "BSD-3-Clause",
   "author": {
     "name": "W3C Verifiable Credentials Working Group",
     "email": "public-vc-wg@w3.org",
     "url": "https://www.w3.org/groups/wg/vc/"
   },
+  "contributors": [
+    {
+      "name": "Digital Bazaar, Inc.",
+      "email": "support@digitalbazaar.com",
+      "url": "https://digitalbazaar.com/"
+    }
+  ],
   "engines": {
     "node": ">=18"
   },

--- a/package.json.license
+++ b/package.json.license
@@ -1,0 +1,3 @@
+Copyright 2024 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/respecConfig.json
+++ b/respecConfig.json
@@ -2,20 +2,20 @@
   "specStatus": "unofficial",
   "shortName": "vc-di-bbs-test-suite",
   "subtitle": "Interoperability test suite for BBS Data Integrity cryptosuite.",
-  "github": "https://github.com/w3c-ccg/vc-di-bbs-test-suite",
-  "edDraftURI": "https://w3c-ccg.github.io/vc-di-bbs-test-suite",
+  "github": "https://github.com/w3c/vc-di-bbs-test-suite",
+  "edDraftURI": "https://w3c.github.io/vc-di-bbs-test-suite",
   "doJsonLd": true,
   "includePermalinks": false,
   "editors": [{
     "name": "Tashi D. Gyeltshen", "url": "https://github.com/jsAssassin",
-    "company": "Digital Bazaar", "companyURL": "http://digitalbazaar.com/"
+    "company": "Digital Bazaar", "companyURL": "https://digitalbazaar.com/"
   }],
   "authors": [{
     "name": "Tashi D. Gyeltshen", "url": "https://github.com/jsAssassin",
-    "company": "Digital Bazaar", "companyURL": "http://digitalbazaar.com/"
+    "company": "Digital Bazaar", "companyURL": "https://digitalbazaar.com/"
   },
   {
-    "name": "Manu Sporny", "url": "http://manu.sporny.org/",
-    "company": "Digital Bazaar", "companyURL": "http://digitalbazaar.com/ "
+    "name": "Manu Sporny", "url": "https://manu.sporny.org/",
+    "company": "Digital Bazaar", "companyURL": "https://digitalbazaar.com/ "
   }]
 }

--- a/respecConfig.json.license
+++ b/respecConfig.json.license
@@ -1,0 +1,3 @@
+Copyright 2024 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/tests/.eslintrc.cjs
+++ b/tests/.eslintrc.cjs
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 module.exports = {
   env: {
     mocha: true

--- a/tests/10-bbs-create.js
+++ b/tests/10-bbs-create.js
@@ -1,6 +1,9 @@
-/*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+/*
+ * Copyright 2023 - 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  */
+
 import chai from 'chai';
 import {
   checkDataIntegrityProofFormat

--- a/tests/20-bbs-verify.js
+++ b/tests/20-bbs-verify.js
@@ -1,6 +1,9 @@
-/*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+/*
+ * Copyright 2023 - 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  */
+
 import {achievementCredential, dlCredentialNoIds, validVc as vc} from
   './mock-data.js';
 import {createDisclosedVc, createInitialVc} from './helpers.js';

--- a/tests/30-bbs-interop.js
+++ b/tests/30-bbs-interop.js
@@ -1,6 +1,9 @@
-/*!
- * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
+/*
+ * Copyright 2023 - 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  */
+
 import {createDisclosedVc, createInitialVc} from './helpers.js';
 import {endpoints} from 'vc-test-suite-implementations';
 import {validVc as vc} from './mock-data.js';

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -1,6 +1,9 @@
-/*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+/*
+ * Copyright 2023 - 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  */
+
 import chai from 'chai';
 
 const should = chai.should();

--- a/tests/didResolver.js
+++ b/tests/didResolver.js
@@ -1,6 +1,9 @@
-/*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+/*
+ * Copyright 2023 - 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  */
+
 import * as didMethodKey from '@digitalbazaar/did-method-key';
 
 const didKeyDriver = didMethodKey.driver();

--- a/tests/documentLoader.js
+++ b/tests/documentLoader.js
@@ -1,6 +1,9 @@
-/*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+/*
+ * Copyright 2023 - 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  */
+
 import {didResolver} from './didResolver.js';
 import {httpClient} from '@digitalbazaar/http-client';
 import https from 'node:https';

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,6 +1,9 @@
-/*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+/*
+ * Copyright 2023 - 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  */
+
 import {klona} from 'klona';
 import {v4 as uuidv4} from 'uuid';
 

--- a/tests/mock-data.js
+++ b/tests/mock-data.js
@@ -1,6 +1,9 @@
-/*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+/*
+ * Copyright 2023 - 2024 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  */
+
 export const validVc = {
   '@context': [
     'https://www.w3.org/2018/credentials/v1',

--- a/w3c.json.license
+++ b/w3c.json.license
@@ -1,0 +1,3 @@
+Copyright 2024 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: BSD-3-Clause


### PR DESCRIPTION
This was moved from the `w3c-ccg` organization on GitHub. This PR provides some
post move cleanup, and applies the BSD-3-Clause license (following the
[REUSE v3.0 specification](https://reuse.software/spec/) 
