### PR TITLE
Add local config readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ SPDX-License-Identifier: BSD-3-Clause
 
 ### Added
 - postinstall the `vc-di-bbs` spec testVectors are cloned into `tests/input`.
+- README section testing locally.
 
 ### Changed
 - **BREAKING:** `vc-test-suite-implementations` now uses the w3c repo and not the w3c-ccg repo.
+- **BREAKING:** Use `localConfig.cjs` over `.localImplementationsConfig.cjs` now.
 
 ## 1.1.0 - 2023-12-14
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ SPDX-License-Identifier: BSD-3-Clause
 - [Background](#background)
 - [Install](#install)
 - [Usage](#usage)
+  - [Testing Locally](#testing-locally)
 - [Implementation](#implementation)
   - [Docker Integration (TODO)](#docker-integration-todo)
 - [Contribute](#contribute)
@@ -31,6 +32,52 @@ npm i
 
 ```sh
 npm test
+```
+
+### Testing Locally
+
+To test a single implementation or endpoint running locally, you can
+copy `localConfig.example.cjs` to `localConfig.cjs`
+in the root directory of the test suite.
+
+```bash
+cp localConfig.example.cjs localConfig.cjs
+```
+
+This file must be a CommonJS module that exports an object containing a
+`settings` object (for configuring the test suite code itself) and an
+`implementations` array (for configuring the implementation(s) to test against).
+
+The format of the object contained in the `implementations` array is
+identical to the one defined in
+[VC Test Suite Implementations](https://github.com/w3c/vc-test-suite-implementations?tab=readme-ov-file#usage)).
+The `implementations` array may contain more than one implementation object, to
+test multiple implementations in one run.
+
+```js
+// .localConfig.cjs defining local implementations
+// you can specify a BASE_URL before running the tests such as:
+// BASE_URL=http://localhost:40443/zDdfsdfs npm test
+const baseUrl = process.env.BASE_URL || 'https://localhost:40443/id';
+module.exports = {
+  settings: {
+    enableInteropTests: false, // default
+    testAllImplementations: false // default
+  },
+  implementations: [{
+    name: 'My Company',
+    implementation: 'My Implementation Name',
+    // only this implementation will be run in the suite
+    issuers: [{
+      id: 'did:key:zMyKey',
+      endpoint: `${baseUrl}/credentials/issue`,
+      tags: ['bbs-2023']
+    }],
+    verifiers: [{
+      endpoint: `${baseUrl}/credentials/verify`,
+      tags: ['bbs-2023']
+    }]
+  }];
 ```
 
 ## Implementation

--- a/localConfig.example.cjs
+++ b/localConfig.example.cjs
@@ -1,0 +1,21 @@
+// Rename this file to localConfig.cjs
+// you can specify a BASE_URL before running the tests such as:
+// BASE_URL=http://localhost:40443/zDdfsdfs npm test
+const baseUrl = process.env.BASE_URL || 'https://localhost:40443/id';
+module.exports = {
+  settings: {},
+  implementations: [{
+    name: 'My Company',
+    implementation: 'My Implementation Name',
+    issuers: [{
+      id: 'did:myMethod:implementation:issuer:id',
+      endpoint: `${baseUrl}/credentials/issue`,
+      tags: ['bbs-2023']
+    }],
+    verifiers: [{
+      id: 'did:myMethod:implementation:verifier:id',
+      endpoint: `${baseUrl}/credentials/verify`,
+      tags: ['bbs-2023']
+    }]
+  }]
+};


### PR DESCRIPTION
Adds a README section for testing locally:

To do:
- [ ] do we need key types for this suite?