### PR TITLE
Update proof value test

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "base64url-universal": "^2.0.0",
     "chai": "^4.3.7",
     "credentials-context": "^2.0.0",
-    "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion#export-helper-funcs",
+    "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion",
     "jsonld-document-loader": "^2.0.0",
     "klona": "^2.0.6",
     "mocha": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@digitalbazaar/vc": "digitalbazaar/vc#update-vc-2.0",
     "@digitalcredentials/did-context": "^1.0.0",
     "base58-universal": "^2.0.0",
+    "base64url-universal": "^2.0.0",
     "chai": "^4.3.7",
     "credentials-context": "^2.0.0",
     "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "base64url-universal": "^2.0.0",
     "chai": "^4.3.7",
     "credentials-context": "^2.0.0",
-    "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion",
+    "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion#export-helper-funcs",
     "jsonld-document-loader": "^2.0.0",
     "klona": "^2.0.6",
     "mocha": "^10.2.0",

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -86,3 +86,13 @@ export const shouldBeMultibaseEncoded = async ({
     `Expected "${propertyName}" to have multicodec prefix ` +
     `"0x${prefixes.multicodec.toString(16)}"`);
 };
+
+export const shouldBeProof = ({proof}) => {
+  should.exist(proof, 'Expected proof to exist.');
+  proof.should.be.an('object', 'Expected proof to be an object.');
+
+};
+
+export const shouldBeBBSProofValue = ({proofValue}) => {
+  const type = typeof proofValue;
+};

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 import {getBs58Bytes, getBs64Bytes} from './helpers.js';
+import {
+  shouldBeBase64NoPadUrl
+} from 'data-integrity-test-suite-assertion';
 import chai from 'chai';
 
 const should = chai.should();
@@ -49,6 +52,24 @@ export const verificationSuccess = async ({credential, verifier}) => {
   );
 };
 
+export const checkEncoding = ({value, propertyName}) => {
+  const [head] = value;
+  if(head === 'z') {
+    return shouldBeBs58(value.slice(1)).should.equal(
+      true,
+      `Expected "${propertyName}" to be bs58 encoded.`
+    );
+  }
+  if(head === 'u') {
+    return shouldBeBase64NoPadUrl(value.slice(1)).should.equal(
+      true,
+      `Expected "${propertyName}" to be bs64 url no pad encoded.`
+    );
+  }
+  throw new Error(`Expected ${propertyName} to start with a multibase ` +
+  `prefix. Received ${head}`);
+};
+
 export const shouldBeMultibaseEncoded = async ({
   expectedLength,
   prefixes = {
@@ -68,12 +89,7 @@ export const shouldBeMultibaseEncoded = async ({
     prefixes.multibase,
     `Expected "${propertyName}" to start with "${prefixes.multibase}"`
   );
-  // z is the bs58 multibase prefix
-  if(prefixes.multibase === 'z') {
-    shouldBeBs58(value.slice(1)).should.equal(
-      true,
-      `Expected "${propertyName}" to be bs58 encoded.`);
-  }
+  checkEncoding({value, propertyName});
   const bytes = await decoder(value);
   if(typeof expectedLength === 'number') {
     bytes.length.should.equal(
@@ -99,5 +115,4 @@ export const shouldBeProofValue = async proofValue => {
     value: proofValue,
     propertyName: 'proofValue'
   });
-
 };

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -87,12 +87,7 @@ export const shouldBeMultibaseEncoded = async ({
     `"0x${prefixes.multicodec.toString(16)}"`);
 };
 
-export const shouldBeProof = ({proof}) => {
-  should.exist(proof, 'Expected proof to exist.');
-  proof.should.be.an('object', 'Expected proof to be an object.');
-
-};
-
-export const shouldBeBBSProofValue = ({proofValue}) => {
-  const type = typeof proofValue;
+export const shouldBeProofValue = proofValue => {
+  should.exist(proofValue, 'Expected proofValue to exist.');
+  proofValue.should.be.a('string', 'Expected proofValue to be a string.');
 };

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -3,9 +3,8 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-
+import {getBs58Bytes, getBs64Bytes} from './helpers.js';
 import chai from 'chai';
-import {getBs58Bytes} from './helpers.js';
 
 const should = chai.should();
 
@@ -76,18 +75,29 @@ export const shouldBeMultibaseEncoded = async ({
       `Expected "${propertyName}" to be bs58 encoded.`);
   }
   const bytes = await decoder(value);
-  bytes.length.should.equal(
-    expectedLength,
-    `Expected "${propertyName}" length to be ${expectedLength}`
-  );
+  if(typeof expectedLength === 'number') {
+    bytes.length.should.equal(
+      expectedLength,
+      `Expected "${propertyName}" length to be ${expectedLength}`
+    );
+  }
   // compare the first two bytes to the expected multicodex prefix
-  bytes.subarray(0, 2).should.eql(
+  bytes.subarray(0, prefixes.multicodec.length).should.eql(
     prefixes.multicodec,
     `Expected "${propertyName}" to have multicodec prefix ` +
     `"0x${prefixes.multicodec.toString(16)}"`);
 };
 
-export const shouldBeProofValue = proofValue => {
+export const shouldBeProofValue = async proofValue => {
   should.exist(proofValue, 'Expected proofValue to exist.');
-  proofValue.should.be.a('string', 'Expected proofValue to be a string.');
+  await shouldBeMultibaseEncoded({
+    prefixes: {
+      multicodec: new Uint8Array([0xd9, 0x5d, 0x02]),
+      multibase: 'u'
+    },
+    decoder: getBs64Bytes,
+    value: proofValue,
+    propertyName: 'proofValue'
+  });
+
 };

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -5,17 +5,12 @@
  */
 import {getBs58Bytes, getBs64Bytes} from './helpers.js';
 import {
-  shouldBeBase64NoPadUrl
+  shouldBeBase64NoPadUrl,
+  shouldBeBs58,
 } from 'data-integrity-test-suite-assertion';
 import chai from 'chai';
 
 const should = chai.should();
-
-// RegExp with bs58 characters in it
-const bs58 =
-  /^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$/;
-// assert something is entirely bs58 encoded
-export const shouldBeBs58 = s => bs58.test(s);
 
 export const verificationFail = async ({credential, verifier}) => {
   const body = {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 import * as bs58 from 'base58-universal';
+import * as bs64 from 'base64url-universal';
 import {createRequire} from 'node:module';
 import {klona} from 'klona';
 import {v4 as uuidv4} from 'uuid';
 
 // remove first element and decode
 export const getBs58Bytes = async s => bs58.decode(s.slice(1));
+export const getBs64Bytes = async s => bs64.decode(s.slice(1));
 export const require = createRequire(import.meta.url);
 
 // Javascript's default ISO timestamp contains milliseconds.

--- a/tests/suites.js
+++ b/tests/suites.js
@@ -69,6 +69,11 @@ export function createSuite({
             '"cryptosuite" property "bbs-2023".'
           );
         });
+        /*
+        * Checked on 04-15-2024.
+        * {@link https://w3c.github.io/vc-di-bbs/#dataintegrityproof}
+        * Link to relevant section above.
+        */
         it('The value of the proofValue property of the proof MUST be a BBS ' +
           'signature or BBS proof produced according to ' +
           '[CFRG-BBS-SIGNATURE] that is serialized and encoded according to ' +

--- a/tests/suites.js
+++ b/tests/suites.js
@@ -6,6 +6,7 @@
 import {createInitialVc, getBs58Bytes, supportsVc} from './helpers.js';
 import {
   shouldBeMultibaseEncoded,
+  shouldBeProofValue,
   verificationFail,
   verificationSuccess
 } from './assertions.js';
@@ -85,10 +86,7 @@ export function createSuite({
             'Expected at least one "bbs-2023" proof'
           );
           for(const proof of bbsProofs) {
-            should.exist(
-              proof.proofValue,
-              'Expected "proof.proofValue" to exist.'
-            );
+            shouldBeProofValue(proof.proofValue);
           }
         });
         it('The "proof" MUST verify when using a conformant verifier.',

--- a/tests/suites.js
+++ b/tests/suites.js
@@ -69,9 +69,10 @@ export function createSuite({
             '"cryptosuite" property "bbs-2023".'
           );
         });
-        it.skip('The value of the "proofValue" property MUST be a BBS ' +
-          'signature or BBS proof produced according to `CFRG-BBS-SIGNATURE`.',
-        function() {
+        it('The value of the proofValue property of the proof MUST be a BBS ' +
+          'signature or BBS proof produced according to ' +
+          '[CFRG-BBS-SIGNATURE] that is serialized and encoded according to ' +
+          'procedures in section 3. Algorithms.', function() {
         });
         it('The "proof" MUST verify when using a conformant verifier.',
           async function() {

--- a/tests/suites.js
+++ b/tests/suites.js
@@ -72,7 +72,7 @@ export function createSuite({
         });
         /*
         * Checked on 04-15-2024.
-        * {@link https://w3c.github.io/vc-di-bbs/#dataintegrityproof}
+        * @link https://w3c.github.io/vc-di-bbs/#dataintegrityproof:~:text=The%20value%20of%20the%20proofValue%20property%20of%20the%20proof%20MUST%20be%20a%20BBS%20signature%20or%20BBS%20proof%20produced%20according%20to%20%5BCFRG%2DBBS%2DSIGNATURE%5D%20that%20is%20serialized%20and%20encoded%20according%20to%20procedures%20in%20section%203.%20Algorithms.
         * Link to relevant section above.
         */
         it('The value of the proofValue property of the proof MUST be a BBS ' +

--- a/tests/suites.js
+++ b/tests/suites.js
@@ -78,6 +78,18 @@ export function createSuite({
           'signature or BBS proof produced according to ' +
           '[CFRG-BBS-SIGNATURE] that is serialized and encoded according to ' +
           'procedures in section 3. Algorithms.', function() {
+          const bbsProofs = proofs.filter(
+            proof => proof.cryptosuite === 'bbs-2023');
+          bbsProofs.length.should.be.gte(
+            1,
+            'Expected at least one "bbs-2023" proof'
+          );
+          for(const proof of bbsProofs) {
+            should.exist(
+              proof.proofValue,
+              'Expected "proof.proofValue" to exist.'
+            );
+          }
         });
         it('The "proof" MUST verify when using a conformant verifier.',
           async function() {

--- a/tests/suites.js
+++ b/tests/suites.js
@@ -72,7 +72,7 @@ export function createSuite({
         });
         /*
         * Checked on 04-15-2024.
-        * @link https://w3c.github.io/vc-di-bbs/#dataintegrityproof:~:text=The%20value%20of%20the%20proofValue%20property%20of%20the%20proof%20MUST%20be%20a%20BBS%20signature%20or%20BBS%20proof%20produced%20according%20to%20%5BCFRG%2DBBS%2DSIGNATURE%5D%20that%20is%20serialized%20and%20encoded%20according%20to%20procedures%20in%20section%203.%20Algorithms.
+        * {@link https://w3c.github.io/vc-di-bbs/#dataintegrityproof:~:text=The%20value%20of%20the%20proofValue%20property%20of%20the%20proof%20MUST%20be%20a%20BBS%20signature%20or%20BBS%20proof%20produced%20according%20to%20%5BCFRG%2DBBS%2DSIGNATURE%5D%20that%20is%20serialized%20and%20encoded%20according%20to%20procedures%20in%20section%203.%20Algorithms.}
         * Link to relevant section above.
         */
         it('The value of the proofValue property of the proof MUST be a BBS ' +

--- a/tests/suites.js
+++ b/tests/suites.js
@@ -78,7 +78,7 @@ export function createSuite({
         it('The value of the proofValue property of the proof MUST be a BBS ' +
           'signature or BBS proof produced according to ' +
           '[CFRG-BBS-SIGNATURE] that is serialized and encoded according to ' +
-          'procedures in section 3. Algorithms.', function() {
+          'procedures in section 3. Algorithms.', async function() {
           const bbsProofs = proofs.filter(
             proof => proof.cryptosuite === 'bbs-2023');
           bbsProofs.length.should.be.gte(
@@ -86,7 +86,7 @@ export function createSuite({
             'Expected at least one "bbs-2023" proof'
           );
           for(const proof of bbsProofs) {
-            shouldBeProofValue(proof.proofValue);
+            await shouldBeProofValue(proof.proofValue);
           }
         });
         it('The "proof" MUST verify when using a conformant verifier.',


### PR DESCRIPTION
Builds on initial config with new test assertions.

1. uses the new shouldBeBs58 and shouldBeBs64UrlNoPad assertions from di assertion
2. adds support for base64 url no pad values
3. adds a new test to the create suite.