### PR TITLE
eslint max-len ignores urls.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,6 +18,7 @@ module.exports = {
     'digitalbazaar/module',
   ],
   rules: {
-    'jsdoc/check-examples': 0
+    'jsdoc/check-examples': 0,
+    'max-len': ['error', {code: 80, ignoreUrls: true}]
   }
 };


### PR DESCRIPTION
Adds an ignore for urls so that google highlight links can be posted as is.