### PR TITLE
Add invalid proof type, cryptosuite, & verificationMethod tests

### DIFF
--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -14,7 +14,11 @@ import {getMultikeys} from './vc-generator/key-gen.js';
 
 const should = chai.should();
 
-export const verificationFail = async ({credential, verifier}) => {
+export const verificationFail = async ({
+  credential,
+  verifier,
+  reason = 'Expected no result from verifier.'
+}) => {
   const body = {
     verifiableCredential: credential,
     options: {
@@ -22,7 +26,7 @@ export const verificationFail = async ({credential, verifier}) => {
     }
   };
   const {result, error} = await verifier.post({json: body});
-  should.not.exist(result, 'Expected no result from verifier.');
+  should.not.exist(result, reason);
   should.exist(error, 'Expected verifier to error.');
   should.exist(error.status, 'Expected verifier to return an HTTP Status code');
   error.status.should.equal(

--- a/tests/suites/create.js
+++ b/tests/suites/create.js
@@ -70,7 +70,7 @@ export function createSuite({
         });
         /*
          * Checked on 2024-04-17.
-         * {@link https://w3c.github.io/vc-di-bbs/#dataintegrityproof}
+         * {@link https://w3c.github.io/vc-di-bbs/#create-base-proof-bbs-2023:~:text=The%20type%20property%20of%20the%20proof%20MUST%20be%20DataIntegrityProof.}
          */
         it('The type property of the proof MUST be DataIntegrityProof.',
           function() {

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -103,6 +103,10 @@ export function verifySuite({
               credential: signedCredentialCopy, verifier
             });
           });
+        /*
+         * Checked on 2024-04-16
+         * @{link https://w3c.github.io/vc-di-bbs/#create-base-proof-bbs-2023:~:text=The%20transformation%20options%20MUST%20contain%20a%20type%20identifier%20for%20the%20cryptographic%20suite%20(type)%2C%20a%20cryptosuite%20identifier%20(cryptosuite)%2C%20and%20a%20verification%20method%20(verificationMethod).}
+         */
         it('The transformation options MUST contain a type identifier for ' +
         'the cryptographic suite (type), a cryptosuite identifier ' +
         '(cryptosuite), and a verification method (verificationMethod).',

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -105,7 +105,7 @@ export function verifySuite({
           });
         /*
          * Checked on 2024-04-16
-         * @{link https://w3c.github.io/vc-di-bbs/#create-base-proof-bbs-2023:~:text=The%20transformation%20options%20MUST%20contain%20a%20type%20identifier%20for%20the%20cryptographic%20suite%20(type)%2C%20a%20cryptosuite%20identifier%20(cryptosuite)%2C%20and%20a%20verification%20method%20(verificationMethod).}
+         * {@link https://w3c.github.io/vc-di-bbs/#create-base-proof-bbs-2023:~:text=The%20transformation%20options%20MUST%20contain%20a%20type%20identifier%20for%20the%20cryptographic%20suite%20(type)%2C%20a%20cryptosuite%20identifier%20(cryptosuite)%2C%20and%20a%20verification%20method%20(verificationMethod).}
          */
         it('The transformation options MUST contain a type identifier for ' +
         'the cryptographic suite (type), a cryptosuite identifier ' +

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -103,6 +103,41 @@ export function verifySuite({
               credential: signedCredentialCopy, verifier
             });
           });
+        it('The transformation options MUST contain a type identifier for ' +
+        'the cryptographic suite (type), a cryptosuite identifier ' +
+        '(cryptosuite), and a verification method (verificationMethod).',
+        async function() {
+          const baseReason = 'Should not verify a VC with no ';
+          const vectors = new Map([
+            ['type identifier', ['type']],
+            ['cryptosuite identifier', ['cryptosuite']],
+            ['verificationMethod', ['verificationMethod']],
+            ['type & no cryptosuite identifier', ['type', 'cryptosuite']],
+            [
+              'type identifier & no verificationMethod',
+              ['type', 'verificationMethod']
+            ],
+            [
+              'cryptosuite identifier & no verificationMethod',
+              ['cryptosuite', 'verificationMethod']
+            ],
+            [
+              'type & no cryptosuite identifier & no verificationMethod',
+              ['type', 'cryptosuite', 'verificationMethod']
+            ]
+          ]);
+          for(const [testReason, terms] of vectors) {
+            const credential = klona(getTestVector(disclosed?.base));
+            for(const prop of terms) {
+              credential.proof[prop] = '';
+            }
+            await verificationFail({
+              credential,
+              verifier,
+              reason: `${baseReason}${testReason}`
+            });
+          }
+        });
       });
     }
   });


### PR DESCRIPTION
1. Adds a new option `reason` to `verificationFail` so test report can see why verification should have failed
2. Adds a new test that simulates what happens when transformation options are invalid.

Statement tested: "The transformation options MUST contain a type identifier for the cryptographic suite (type), a cryptosuite identifier (cryptosuite), and a verification method (verificationMethod). "