### PR TITLE
Move transformation options create

### DIFF
--- a/tests/suites/create.js
+++ b/tests/suites/create.js
@@ -3,13 +3,13 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-import {createInitialVc, getBs58Bytes, supportsVc} from '../helpers.js';
 import {
   checkEncoding,
   shouldBeMultibaseEncoded,
   shouldBeProofValue,
   shouldVerifyDerivedProof
 } from '../assertions.js';
+import {createInitialVc, getBs58Bytes, supportsVc} from '../helpers.js';
 import chai from 'chai';
 import {documentLoader} from '../documentLoader.js';
 

--- a/tests/suites/create.js
+++ b/tests/suites/create.js
@@ -182,6 +182,18 @@ export function createSuite({
             expectedLength: 98
           });
         });
+        /*
+         * Checked on 2024-04-16
+         * {@link https://w3c.github.io/vc-di-bbs/#create-base-proof-bbs-2023:~:text=The%20transformation%20options%20MUST%20contain%20a%20type%20identifier%20for%20the%20cryptographic%20suite%20(type)%2C%20a%20cryptosuite%20identifier%20(cryptosuite)%2C%20and%20a%20verification%20method%20(verificationMethod).}
+         *
+         * NOTE: this suite can not control the transformation options so it
+         * just checks the proof was created correctly.
+         */
+        it('The transformation options MUST contain a type identifier for ' +
+        'the cryptographic suite (type), a cryptosuite identifier ' +
+        '(cryptosuite), and a verification method (verificationMethod).',
+        async function() {
+        });
       });
     }
   });

--- a/tests/suites/create.js
+++ b/tests/suites/create.js
@@ -5,6 +5,7 @@
  */
 import {createInitialVc, getBs58Bytes, supportsVc} from '../helpers.js';
 import {
+  checkEncoding,
   shouldBeMultibaseEncoded,
   shouldBeProofValue,
   shouldVerifyDerivedProof
@@ -193,6 +194,38 @@ export function createSuite({
         'the cryptographic suite (type), a cryptosuite identifier ' +
         '(cryptosuite), and a verification method (verificationMethod).',
         async function() {
+          bbsProofs.length.should.be.gte(
+            1,
+            'Expected at least one "bbs-2023" proof'
+          );
+          for(const proof of bbsProofs) {
+            should.exist(proof.type, 'Expected "proof.type" to exist.');
+            proof.type.should.equal(
+              'DataIntegrityProof',
+              'Expected "proof.type" to equal "DataIntegrityProof.'
+            );
+            should.exist(
+              proof.cryptosuite,
+              'Expected "proof.cryptosuite" to exist.'
+            );
+            proof.cryptosuite.should.equal(
+              'bbs-2023',
+              'Expected "proof.cryptosuite" to equal "bbs-2023"'
+            );
+            should.exist(
+              proof.verificationMethod,
+              'Expected "proof.verificationMethod" to exist.'
+            );
+            proof.verificationMethod.should.be.a(
+              'string',
+              'Expected "proof.verificationMethod" to be a string.'
+            );
+            const [publicKey] = proof.verificationMethod.split('#');
+            checkEncoding({
+              value: publicKey.substr(8),
+              propertyName: 'proof.verificationMethod'
+            });
+          }
         });
       });
     }

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -103,45 +103,6 @@ export function verifySuite({
               credential: signedCredentialCopy, verifier
             });
           });
-        /*
-         * Checked on 2024-04-16
-         * {@link https://w3c.github.io/vc-di-bbs/#create-base-proof-bbs-2023:~:text=The%20transformation%20options%20MUST%20contain%20a%20type%20identifier%20for%20the%20cryptographic%20suite%20(type)%2C%20a%20cryptosuite%20identifier%20(cryptosuite)%2C%20and%20a%20verification%20method%20(verificationMethod).}
-         */
-        it('The transformation options MUST contain a type identifier for ' +
-        'the cryptographic suite (type), a cryptosuite identifier ' +
-        '(cryptosuite), and a verification method (verificationMethod).',
-        async function() {
-          const baseReason = 'Should not verify a VC with no ';
-          const vectors = new Map([
-            ['type identifier', ['type']],
-            ['cryptosuite identifier', ['cryptosuite']],
-            ['verificationMethod', ['verificationMethod']],
-            ['type & no cryptosuite identifier', ['type', 'cryptosuite']],
-            [
-              'type identifier & no verificationMethod',
-              ['type', 'verificationMethod']
-            ],
-            [
-              'cryptosuite identifier & no verificationMethod',
-              ['cryptosuite', 'verificationMethod']
-            ],
-            [
-              'type & no cryptosuite identifier & no verificationMethod',
-              ['type', 'cryptosuite', 'verificationMethod']
-            ]
-          ]);
-          for(const [testReason, terms] of vectors) {
-            const credential = klona(getTestVector(disclosed?.base));
-            for(const prop of terms) {
-              credential.proof[prop] = '';
-            }
-            await verificationFail({
-              credential,
-              verifier,
-              reason: `${baseReason}${testReason}`
-            });
-          }
-        });
       });
     }
   });


### PR DESCRIPTION
Corrects a mistake: the transformation options are for base proofs only so it moves the transformation options test to create where is actually provides some decent value. You can not verify a base proof so it's hard for this to be a verifier test.