### PR TITLE
(7) Add invalid date test

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -212,6 +212,10 @@ export async function verifySetup({credentials, keyTypes, suite}) {
     keys,
     vectors: transformVectors(subjectNestedObjects),
     suiteName: suite,
+    initialParams: {
+      // disclosed suite has no created
+      selectiveSuite: null
+    },
     generators: [invalidCreated]
   });
   return {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -6,7 +6,8 @@ import * as base64url from 'base64url-universal';
 import {
   allowUnsafeCanonize,
   invalidCborEncoding,
-  invalidStringEncoding
+  invalidStringEncoding,
+  passCreated
 } from './vc-generator/generators.js';
 import {
   deriveCredentials,
@@ -212,12 +213,7 @@ export async function verifySetup({credentials, keyTypes, suite}) {
     keys,
     vectors: transformVectors(subjectNestedObjects),
     suiteName: suite,
-    initialParams: {
-      // FIXME while created is not recommended for bbs it should be in
-      // the disclosed VC too.
-      selectiveSuite: null
-    },
-    generators: [invalidCreated]
+    generators: [invalidCreated, passCreated]
   });
   return {
     base,

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -130,7 +130,8 @@ export async function verifySetup({credentials, keyTypes, suite}) {
     suiteName: suite,
     keys
   });
-  const {mandatory} = generators;
+  const {mandatory, created} = generators;
+  const {invalidCreated} = created;
   const {invalidCryptosuite, invalidProofType} = mandatory;
   disclosed.invalid.proofTypeAndCryptosuite =
     await deriveCredentials({
@@ -207,6 +208,12 @@ export async function verifySetup({credentials, keyTypes, suite}) {
     }
   }
   disclosed.invalid.valuePrefix = valuePrefix;
+  disclosed.invalid.created = await deriveCredentials({
+    keys,
+    vectors: transformVectors(subjectNestedObjects),
+    suiteName: suite,
+    generators: [invalidCreated]
+  });
   return {
     base,
     disclosed

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -213,7 +213,8 @@ export async function verifySetup({credentials, keyTypes, suite}) {
     vectors: transformVectors(subjectNestedObjects),
     suiteName: suite,
     initialParams: {
-      // disclosed suite has no created
+      // FIXME while created is not recommended for bbs it should be in
+      // the disclosed VC too.
       selectiveSuite: null
     },
     generators: [invalidCreated]

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -154,10 +154,10 @@ export function verifySuite({
             verifier
           });
         });
-        it('If proofConfig.created is set and the value is not a valid ' +
-        '[XMLSCHEMA11-2] datetime, an INVALID_PROOF_DATETIME error MUST be ' +
-        'raised.', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-bbs/#linkage-via-proof-options-and-mandatory-reveal:~:text=If%20proofConfig.created%20is%20set%20and%20if%20the%20value%20is%20not%20a%20valid%20%5BXMLSCHEMA11%2D2%5D%20datetime%2C%20an%20INVALID_PROOF_DATETIME%20error%20MUST%20be%20raised.';
+        it('If proofConfig.created is set and if the value is not a valid ' +
+        '[XMLSCHEMA11-2] datetime, an error MUST be raised and SHOULD convey ' +
+        'an error type of PROOF_GENERATION_ERROR.', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-bbs/#:~:text=If%20proofConfig.created%20is%20set%20and%20if%20the%20value%20is%20not%20a%20valid%20%5BXMLSCHEMA11%2D2%5D%20datetime%2C%20an%20error%20MUST%20be%20raised%20and%20SHOULD%20convey%20an%20error%20type%20of%20PROOF_GENERATION_ERROR.';
           const credential = cloneTestVector(disclosed?.invalid?.created);
           //FIXME assert on error code or message when available
           await verificationFail({credential, verifier});

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -154,7 +154,7 @@ export function verifySuite({
             verifier
           });
         });
-        it('If proofConfig.created is set and if the value is not a valid ' +
+        it('If proofConfig.created is set and the value is not a valid ' +
         '[XMLSCHEMA11-2] datetime, an INVALID_PROOF_DATETIME error MUST be ' +
         'raised.', async function() {
           this.test.link = 'https://w3c.github.io/vc-di-bbs/#linkage-via-proof-options-and-mandatory-reveal:~:text=If%20proofConfig.created%20is%20set%20and%20if%20the%20value%20is%20not%20a%20valid%20%5BXMLSCHEMA11%2D2%5D%20datetime%2C%20an%20INVALID_PROOF_DATETIME%20error%20MUST%20be%20raised.';

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -160,8 +160,6 @@ export function verifySuite({
           this.test.link = 'https://w3c.github.io/vc-di-bbs/#linkage-via-proof-options-and-mandatory-reveal:~:text=If%20proofConfig.created%20is%20set%20and%20if%20the%20value%20is%20not%20a%20valid%20%5BXMLSCHEMA11%2D2%5D%20datetime%2C%20an%20INVALID_PROOF_DATETIME%20error%20MUST%20be%20raised.';
           const credential = cloneTestVector(disclosed?.invalid?.created);
           //FIXME assert on error code or message when available
-          //a base proof will fail verification in any case
-          //we need to know the specific reason it fails
           await verificationFail({credential, verifier});
         });
         it('MUST fail to verify a base proof.', async function() {

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -158,8 +158,10 @@ export function verifySuite({
         '[XMLSCHEMA11-2] datetime, an INVALID_PROOF_DATETIME error MUST be ' +
         'raised.', async function() {
           this.test.link = 'https://w3c.github.io/vc-di-bbs/#linkage-via-proof-options-and-mandatory-reveal:~:text=If%20proofConfig.created%20is%20set%20and%20if%20the%20value%20is%20not%20a%20valid%20%5BXMLSCHEMA11%2D2%5D%20datetime%2C%20an%20INVALID_PROOF_DATETIME%20error%20MUST%20be%20raised.';
-          const credential = cloneTestVector(
-            disclosed?.invalid?.created);
+          const credential = cloneTestVector(disclosed?.invalid?.created);
+          //FIXME assert on error code or message when available
+          //a base proof will fail verification in any case
+          //we need to know the specific reason it fails
           await verificationFail({credential, verifier});
         });
         it('MUST fail to verify a base proof.', async function() {

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -154,6 +154,14 @@ export function verifySuite({
             verifier
           });
         });
+        it('If proofConfig.created is set and if the value is not a valid ' +
+        '[XMLSCHEMA11-2] datetime, an INVALID_PROOF_DATETIME error MUST be ' +
+        'raised.', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-bbs/#linkage-via-proof-options-and-mandatory-reveal:~:text=If%20proofConfig.created%20is%20set%20and%20if%20the%20value%20is%20not%20a%20valid%20%5BXMLSCHEMA11%2D2%5D%20datetime%2C%20an%20INVALID_PROOF_DATETIME%20error%20MUST%20be%20raised.';
+          const credential = cloneTestVector(
+            disclosed?.invalid?.created);
+          await verificationFail({credential, verifier});
+        });
         it('MUST fail to verify a base proof.', async function() {
           const credential = cloneTestVector(base);
           await verificationFail({credential, verifier});

--- a/tests/vc-generator/generators.js
+++ b/tests/vc-generator/generators.js
@@ -13,6 +13,14 @@ export function allowUnsafeCanonize({suite, selectiveSuite, ...args}) {
   return {...args, suite, selectiveSuite};
 }
 
+export function passCreated({suite, ...args}) {
+  suite._cryptosuite = stubMethods({
+    object: suite._cryptosuite,
+    stubs: {createVerifyData: stubs.stubVerifyData({deleteCreated: false})},
+  });
+  return {...args, suite};
+}
+
 export function invalidStringEncoding({suite, selectiveSuite, ...args}) {
   suite._cryptosuite = stubMethods({
     object: suite._cryptosuite,

--- a/tests/vc-generator/index.js
+++ b/tests/vc-generator/index.js
@@ -110,6 +110,7 @@ export async function deriveCredentials({
         suite: getSuite({suite: suiteName, signer, mandatoryPointers}),
         selectiveSuite: getSuite({suite: suiteName, signer, selectivePointers}),
         credential: _credential,
+        // add the ability to overwrite the defaults
         ...initialParams
       };
       // call each generator on itself to produce accumulated invalid suites


### PR DESCRIPTION
Adds an invalid created test for the base and by extension derived proof.

TODO
- [x] Use a generator to ensure created still shows up in the proof until the implementation used for test data creation can support `proof.created`.