### PR TITLE
Declutter setup

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -42,8 +42,8 @@ export async function verifySetup({credentials, keyTypes, suite}) {
       return [vcVersion, func(structuredClone(vector))];
     });
 
-  // create initial signed VCs
-  const signed = await issueCredentials({
+  // create initial base proofs
+  const base = await issueCredentials({
     credentials: Object.entries(subjectNestedObjects),
     suite,
     keyTypes
@@ -136,7 +136,7 @@ export async function verifySetup({credentials, keyTypes, suite}) {
     generators: [invalidCryptosuite]
   });
   return {
-    signed,
+    base,
     disclosed
   };
 }

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -12,7 +12,7 @@ import {generators} from 'data-integrity-test-suite-assertion';
 export async function verifySetup({credentials, keyTypes, suite}) {
   const disclosed = {
     //disclosedCredentials
-    base: new Map(),
+    basic: new Map(),
     //nestedDisclosedCredentials
     nested: new Map(),
     //disclosedDlCredentialNoIds
@@ -48,15 +48,15 @@ export async function verifySetup({credentials, keyTypes, suite}) {
     suite,
     keyTypes
   });
-  const disclosedBaseVectors = transformVectors(
+  const disclosedBasicVectors = transformVectors(
     subjectNestedObjects,
     vector => {
       vector.selectivePointers = ['/credentialSubject/id'];
       return vector;
     });
   // use initial VCs for a basic selective disclosure test
-  disclosed.base = await deriveCredentials({
-    vectors: disclosedBaseVectors,
+  disclosed.basic = await deriveCredentials({
+    vectors: disclosedBasicVectors,
     suiteName: suite,
     keys
   });

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -47,7 +47,7 @@ export function verifySuite({
             columnId: name, rowId: this.currentTest.title
           };
         });
-        const {disclosed, signed} = credentials;
+        const {disclosed, base} = credentials;
         const cloneTestVector = map => structuredClone(
           map?.get(keyType)?.get(vcVersion));
         it('MUST verify a valid VC with a bbs-2023 proof.',
@@ -102,7 +102,7 @@ export function verifySuite({
           await verificationFail({credential, verifier});
         });
         it('MUST fail to verify a base proof.', async function() {
-          const credential = cloneTestVector(signed);
+          const credential = cloneTestVector(base);
           await verificationFail({credential, verifier});
         });
         it('MUST fail to verify a modified disclosed credential.',

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -52,7 +52,7 @@ export function verifySuite({
           map?.get(keyType)?.get(vcVersion));
         it('MUST verify a valid VC with a bbs-2023 proof.',
           async function() {
-            const credential = cloneTestVector(disclosed?.base);
+            const credential = cloneTestVector(disclosed?.basic);
             await verificationSuccess({credential, verifier});
           });
         it('MUST verify a valid VC with nested disclosed properties.',
@@ -83,7 +83,7 @@ export function verifySuite({
           });
         it('If the "proofValue" string does not start with "u", an ' +
           'error MUST be raised.', async function() {
-          const credential = cloneTestVector(disclosed?.base);
+          const credential = cloneTestVector(disclosed?.basic);
           // intentionally modify proofValue to not start with 'u'
           credential.proof.proofValue = 'a';
           await verificationFail({credential, verifier});
@@ -107,7 +107,7 @@ export function verifySuite({
         });
         it('MUST fail to verify a modified disclosed credential.',
           async function() {
-            const credential = cloneTestVector(disclosed?.base);
+            const credential = cloneTestVector(disclosed?.basic);
             // intentionally modify `credentialSubject` ID
             credential.credentialSubject.id = 'urn:invalid';
             await verificationFail({credential, verifier});


### PR DESCRIPTION
Improvements:

1. setup no longer has testVectors in it it just returns an object.
2. setup no longer considers VCs with just base proofs signed, base proof VCs are in base
3. setup now disambiguates between disclosed basic VCs and base VCs, simple disclosed VCs are basic