### PR TITLE
(2) Unset proof type cryptosuite

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -138,6 +138,17 @@ export async function verifySetup({credentials, keyTypes, suite}) {
     suiteName: suite,
     generators: [invalidCryptosuite]
   });
+  disclosed.invalid.noProofTypeOrCryptosuite = await deriveCredentials({
+    keys,
+    vectors: disclosedBasicVectors,
+    suiteName: suite,
+    initialParams: {
+      proofType: '',
+      cryptosuiteName: ''
+    },
+    generators: [invalidProofType, invalidCryptosuite]
+  });
+console.log(JSON.stringify(disclosed.invalid.noProofTypeOrCryptosuite.get('P-381').get('2.0'), null, 2));
   disclosed.invalid.nonUTF8 = await deriveCredentials({
     keys,
     vectors: disclosedBasicVectors,

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -8,7 +8,7 @@ import {
   issueCredentials
 } from './vc-generator/index.js';
 import {generators} from 'data-integrity-test-suite-assertion';
-import {invalidStringEncoding} from './vc-generator/generators.js';
+import {noProofTypeorCryptosuite, invalidStringEncoding} from './vc-generator/generators.js';
 
 export async function verifySetup({credentials, keyTypes, suite}) {
   const disclosed = {
@@ -146,9 +146,9 @@ export async function verifySetup({credentials, keyTypes, suite}) {
       proofType: '',
       cryptosuiteName: ''
     },
-    generators: [invalidProofType, invalidCryptosuite]
+    // add a generator to turns safe mode off for proof cannonize and hash
+    generators: [noProofTypeorCryptosuite, invalidProofType, invalidCryptosuite]
   });
-console.log(JSON.stringify(disclosed.invalid.noProofTypeOrCryptosuite.get('P-381').get('2.0'), null, 2));
   disclosed.invalid.nonUTF8 = await deriveCredentials({
     keys,
     vectors: disclosedBasicVectors,

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -149,7 +149,7 @@ export async function verifySetup({credentials, keyTypes, suite}) {
       proofType: '',
       cryptosuiteName: ''
     },
-    // add a generator to turns safe mode off for proof cannonize and hash
+    // add a generator to turn safe mode off for proof, canonize, and hash
     generators: [noProofTypeorCryptosuite, invalidProofType, invalidCryptosuite]
   });
   disclosed.invalid.nonUTF8 = await deriveCredentials({

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -7,8 +7,11 @@ import {
   getMultikeys,
   issueCredentials
 } from './vc-generator/index.js';
+import {
+  invalidStringEncoding,
+  noProofTypeorCryptosuite
+} from './vc-generator/generators.js';
 import {generators} from 'data-integrity-test-suite-assertion';
-import {noProofTypeorCryptosuite, invalidStringEncoding} from './vc-generator/generators.js';
 
 export async function verifySetup({credentials, keyTypes, suite}) {
   const disclosed = {

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -107,6 +107,16 @@ export function verifySuite({
           const credential = cloneTestVector(disclosed?.invalid?.nonUTF8);
           await verificationFail({credential, verifier});
         });
+        it('The proof options MUST contain a type identifier for the ' +
+        'cryptographic suite (type) and MUST contain a cryptosuite ' +
+        'identifier (cryptosuite). A proof configuration object is produced ' +
+        'as output.', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-bbs/#linkage-via-proof-options-and-mandatory-reveal:~:text=The%20proof%20options%20MUST%20contain%20a%20type%20identifier%20for%20the%20cryptographic%20suite%20(type)%20and%20MUST%20contain%20a%20cryptosuite%20identifier%20(cryptosuite).%20A%20proof%20configuration%20object%20is%20produced%20as%20output.';
+          const credential = cloneTestVector(
+            disclosed?.invalid?.noProofTypeOrCryptosuite);
+          await verificationFail({credential, verifier});
+        });
+
         it('MUST fail to verify a base proof.', async function() {
           const credential = cloneTestVector(base);
           await verificationFail({credential, verifier});

--- a/tests/vc-generator/generators.js
+++ b/tests/vc-generator/generators.js
@@ -2,49 +2,23 @@
  * Copyright (c) 2024 Digital Bazaar, Inc.
  * SPDX-License-Identifier: BSD-3-Clause
  */
-import * as cborg from 'cborg';
-import {concatBuffers, serializeBaseProofValue} from
-  '../../node_modules/@digitalbazaar/bbs-2023-cryptosuite/lib/proofValue.js';
+import * as mocks from './mockMethods.js';
 
-const TEXT_ENCODER = new TextEncoder();
+export function noProofTypeorCryptosuite({
+  suite,
+  selectiveSuite,
+  proofType,
+  cryptosuiteName,
+  ...args}) {
+
+  return {...args, suite, selectiveSuite, proofType, cryptosuiteName};
+}
 
 export function invalidStringEncoding({suite, selectiveSuite, ...args}) {
   suite._cryptosuite = new Proxy(suite._cryptosuite, {
     get(target, prop) {
       if(prop === 'createProofValue') {
-        return async function({verifyData, dataIntegrityProof}) {
-          const {signer} = dataIntegrityProof;
-          const {
-            proofHash, mandatoryPointers, mandatoryHash, nonMandatory, hmacKey
-          } = verifyData;
-          // 1. Set BBS header to the concatenation of `proofHash` and
-          // `mandatoryHash`.
-          const bbsHeader = concatBuffers([proofHash, mandatoryHash]);
-
-          // 2. Set BBS messages to all non-mandatory messages using
-          // invalid UTF-8 encoding.
-          const messages = nonMandatory.map(str => {
-            return TEXT_ENCODER.encode(str).map(c => c + 1);
-          });
-          // 3. Create BBS signature.
-          const {publicKey} = signer;
-          let bbsSignature;
-          // use `multisign` if provided; otherwise, use CBOR
-          // to encode `data` for `sign`
-          if(signer.multisign) {
-            bbsSignature = await signer.multisign({
-              header: bbsHeader, messages});
-          } else {
-            const data = cborg.encode([bbsHeader, messages]);
-            bbsSignature = await signer.sign({data});
-          }
-
-          // 4. Generate `proofValue`.
-          const proofValue = serializeBaseProofValue({
-            bbsSignature, bbsHeader, publicKey, hmacKey, mandatoryPointers
-          });
-          return proofValue;
-        };
+        return mocks.createProofValue;
       }
       // if a stub is not found, return the original property
       return Reflect.get(...arguments);

--- a/tests/vc-generator/generators.js
+++ b/tests/vc-generator/generators.js
@@ -7,22 +7,40 @@ import * as mocks from './mockMethods.js';
 export function noProofTypeorCryptosuite({
   suite,
   selectiveSuite,
-  proofType,
-  cryptosuiteName,
   ...args}) {
-
-  return {...args, suite, selectiveSuite, proofType, cryptosuiteName};
+  suite._cryptosuite = _proxyStub({
+    object: suite._cryptosuite,
+    mocks: {createVerifyData: mocks.createVerifyData},
+  });
+  return {...args, suite, selectiveSuite};
 }
 
 export function invalidStringEncoding({suite, selectiveSuite, ...args}) {
-  suite._cryptosuite = new Proxy(suite._cryptosuite, {
+  suite._cryptosuite = _proxyStub({
+    object: suite._cryptosuite,
+    mocks: {createProofValue: mocks.createProofValue}
+  });
+  return {...args, suite, selectiveSuite};
+}
+
+/**
+ * Creates a Proxy around a method on an object.
+ *
+ * @param {object} options - Options to use.
+ * @param {object} options.object - The object to proxy.
+ * @param {{[key: string]: Function}} options.mocks - A collection of mock
+ *   methods.
+ *
+ * @returns {Proxy} - Returns a Proxy.
+ */
+function _proxyStub({object, mocks}) {
+  return new Proxy(object, {
     get(target, prop) {
-      if(prop === 'createProofValue') {
-        return mocks.createProofValue;
+      const mock = mocks[prop];
+      if(mock) {
+        return mock;
       }
-      // if a stub is not found, return the original property
       return Reflect.get(...arguments);
     }
   });
-  return {...args, suite, selectiveSuite};
 }

--- a/tests/vc-generator/index.js
+++ b/tests/vc-generator/index.js
@@ -96,6 +96,7 @@ export async function deriveCredentials({
   vectors,
   map = new Map(),
   suiteName,
+  initialParams,
   generators = []
 }) {
   for(const [keyType, {signer, issuer}] of keys) {
@@ -108,7 +109,8 @@ export async function deriveCredentials({
       const initParams = {
         suite: getSuite({suite: suiteName, signer, mandatoryPointers}),
         selectiveSuite: getSuite({suite: suiteName, signer, selectivePointers}),
-        credential: _credential
+        credential: _credential,
+        ...initialParams
       };
       // call each generator on itself to produce accumulated invalid suites
       // and vectors

--- a/tests/vc-generator/mockMethods.js
+++ b/tests/vc-generator/mockMethods.js
@@ -1,8 +1,17 @@
 import * as cborg from 'cborg';
+import {
+  canonicalizeAndGroup,
+  createHmac,
+  hashCanonizedProof,
+  hashMandatory,
+} from '@digitalbazaar/di-sd-primitives';
 import {concatBuffers, serializeBaseProofValue} from
   '../../node_modules/@digitalbazaar/bbs-2023-cryptosuite/lib/proofValue.js';
+import {createShuffledIdLabelMapFunction} from
+  '../../node_modules/@digitalbazaar/bbs-2023-cryptosuite/lib/sdFunctions.js';
 
 const TEXT_ENCODER = new TextEncoder();
+const name = 'bbs-2023';
 
 export async function createProofValue({verifyData, dataIntegrityProof}) {
   const {signer} = dataIntegrityProof;
@@ -36,4 +45,60 @@ export async function createProofValue({verifyData, dataIntegrityProof}) {
     bbsSignature, bbsHeader, publicKey, hmacKey, mandatoryPointers
   });
   return proofValue;
+}
+
+export async function createVerifyData({
+  cryptosuite, document, proof, documentLoader
+}) {
+  if(cryptosuite?.name !== name) {
+    throw new TypeError(`"cryptosuite.name" must be "${name}".`);
+  }
+  if(!(cryptosuite.options && typeof cryptosuite.options === 'object')) {
+    throw new TypeError(`"cryptosuite.options" must be an object.`);
+  }
+  const {mandatoryPointers = []} = cryptosuite.options;
+  if(!Array.isArray(mandatoryPointers)) {
+    throw new TypeError(
+      `"cryptosuite.options.mandatoryPointers" must be an array.`);
+  }
+
+  // 0. Remove `created` from proof if present.
+  // FIXME: implement `updateProof` or another method to ensure `created`
+  // is not set once some API is exposed via `data-integrity`
+  delete proof.created;
+
+  // 1. Generate `proofHash` in parallel.
+  const options = {documentLoader, safe: false};
+  const proofHashPromise = hashCanonizedProof({document, proof, options})
+    .catch(e => e);
+
+  // 2. Create HMAC label replacement function to randomize bnode labels.
+  const hmac = await createHmac({key: null});
+  const labelMapFactoryFunction = createShuffledIdLabelMapFunction({hmac});
+
+  // 3. Canonicalize document with randomized bnode labels and group N-Quads
+  //  by mandatory pointers.
+  const {
+    groups: {mandatory: mandatoryGroup}
+  } = await canonicalizeAndGroup({
+    document,
+    labelMapFactoryFunction,
+    groups: {mandatory: mandatoryPointers},
+    options
+  });
+  const mandatory = [...mandatoryGroup.matching.values()];
+  const nonMandatory = [...mandatoryGroup.nonMatching.values()];
+
+  // 4. Hash any mandatory N-Quads.
+  const {mandatoryHash} = await hashMandatory({mandatory});
+
+  // 5. Export HMAC key.
+  const hmacKey = await hmac.export();
+
+  // 6. Return data used by cryptosuite to sign.
+  const proofHash = await proofHashPromise;
+  if(proofHash instanceof Error) {
+    throw proofHash;
+  }
+  return {proofHash, mandatoryPointers, mandatoryHash, nonMandatory, hmacKey};
 }

--- a/tests/vc-generator/mockMethods.js
+++ b/tests/vc-generator/mockMethods.js
@@ -1,0 +1,39 @@
+import * as cborg from 'cborg';
+import {concatBuffers, serializeBaseProofValue} from
+  '../../node_modules/@digitalbazaar/bbs-2023-cryptosuite/lib/proofValue.js';
+
+const TEXT_ENCODER = new TextEncoder();
+
+export async function createProofValue({verifyData, dataIntegrityProof}) {
+  const {signer} = dataIntegrityProof;
+  const {
+    proofHash, mandatoryPointers, mandatoryHash, nonMandatory, hmacKey
+  } = verifyData;
+  // 1. Set BBS header to the concatenation of `proofHash` and
+  // `mandatoryHash`.
+  const bbsHeader = concatBuffers([proofHash, mandatoryHash]);
+
+  // 2. Set BBS messages to all non-mandatory messages using
+  // invalid UTF-8 encoding.
+  const messages = nonMandatory.map(str => {
+    return TEXT_ENCODER.encode(str).map(c => c + 1);
+  });
+  // 3. Create BBS signature.
+  const {publicKey} = signer;
+  let bbsSignature;
+  // use `multisign` if provided, otherwise use CBOR
+  // to encode `data` for `sign`
+  if(signer.multisign) {
+    bbsSignature = await signer.multisign({
+      header: bbsHeader, messages});
+  } else {
+    const data = cborg.encode([bbsHeader, messages]);
+    bbsSignature = await signer.sign({data});
+  }
+
+  // 4. Generate `proofValue`.
+  const proofValue = serializeBaseProofValue({
+    bbsSignature, bbsHeader, publicKey, hmacKey, mandatoryPointers
+  });
+  return proofValue;
+}


### PR DESCRIPTION
Features:

1. adds a new function to stub methods on an object.
2. stubs `createVerifyData` so that canonize can be done unsafely with empty string values.
3. adds a test for "The proof options MUST contain a type identifier for the [cryptographic suite](https://www.w3.org/TR/vc-data-integrity/#dfn-cryptosuite) (type) and MUST contain a cryptosuite identifier (cryptosuite). A proof configuration object is produced as output."