### PR TITLE
(3) Expand proof type and cryptosuite vectors.

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -169,7 +169,7 @@ export async function verifySetup({credentials, keyTypes, suite}) {
     initialParams: {
       cryptosuiteName: ''
     },
-    // add a generator to turns safe mode off for proof canonize and hash
+    // add a generator to turn safe mode off for proof, canonize, and hash
     generators: [allowUnsafeCanonize, invalidCryptosuite]
   });
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 import {
+  allowUnsafeCanonize,
+  invalidStringEncoding
+} from './vc-generator/generators.js';
+import {
   deriveCredentials,
   getMultikeys,
   issueCredentials
 } from './vc-generator/index.js';
-import {
-  invalidStringEncoding,
-  noProofTypeorCryptosuite
-} from './vc-generator/generators.js';
 import {generators} from 'data-integrity-test-suite-assertion';
 
 export async function verifySetup({credentials, keyTypes, suite}) {
@@ -150,7 +150,17 @@ export async function verifySetup({credentials, keyTypes, suite}) {
       cryptosuiteName: ''
     },
     // add a generator to turn safe mode off for proof, canonize, and hash
-    generators: [noProofTypeorCryptosuite, invalidProofType, invalidCryptosuite]
+    generators: [allowUnsafeCanonize, invalidProofType, invalidCryptosuite]
+  });
+  disclosed.invalid.noProofType = await deriveCredentials({
+    keys,
+    vectors: disclosedBasicVectors,
+    suiteName: suite,
+    initialParams: {
+      proofType: '',
+    },
+    // add a generator to turn safe mode off for proof, canonize, and hash
+    generators: [allowUnsafeCanonize, invalidProofType]
   });
   disclosed.invalid.nonUTF8 = await deriveCredentials({
     keys,

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -162,6 +162,17 @@ export async function verifySetup({credentials, keyTypes, suite}) {
     // add a generator to turn safe mode off for proof, canonize, and hash
     generators: [allowUnsafeCanonize, invalidProofType]
   });
+  disclosed.invalid.noCryptosuite = await deriveCredentials({
+    keys,
+    vectors: disclosedBasicVectors,
+    suiteName: suite,
+    initialParams: {
+      cryptosuiteName: ''
+    },
+    // add a generator to turns safe mode off for proof canonize and hash
+    generators: [allowUnsafeCanonize, invalidCryptosuite]
+  });
+
   disclosed.invalid.nonUTF8 = await deriveCredentials({
     keys,
     vectors: disclosedBasicVectors,

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -116,6 +116,21 @@ export function verifySuite({
             disclosed?.invalid?.noProofTypeOrCryptosuite);
           await verificationFail({credential, verifier});
         });
+        it('The proof options MUST contain a type identifier for the ' +
+        'cryptographic suite (type) and MAY contain a cryptosuite ' +
+        'identifier (cryptosuite).', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-bbs/#linkage-via-proof-options-and-mandatory-reveal:~:text=The%20proof%20options%20MUST%20contain%20a%20type%20identifier%20for%20the%20cryptographic%20suite%20(type)%20and%20MAY%20contain%20a%20cryptosuite%20identifier%20(cryptosuite).';
+          await verificationFail({
+            credential: cloneTestVector(
+              disclosed?.invalid?.noProofTypeOrCryptosuite),
+            verifier
+          });
+          await verificationFail({
+            credential: cloneTestVector(
+              disclosed?.invalid?.noProofType),
+            verifier
+          });
+        });
 
         it('MUST fail to verify a base proof.', async function() {
           const credential = cloneTestVector(base);

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -112,14 +112,6 @@ export function verifySuite({
         'identifier (cryptosuite). A proof configuration object is produced ' +
         'as output.', async function() {
           this.test.link = 'https://w3c.github.io/vc-di-bbs/#linkage-via-proof-options-and-mandatory-reveal:~:text=The%20proof%20options%20MUST%20contain%20a%20type%20identifier%20for%20the%20cryptographic%20suite%20(type)%20and%20MUST%20contain%20a%20cryptosuite%20identifier%20(cryptosuite).%20A%20proof%20configuration%20object%20is%20produced%20as%20output.';
-          const credential = cloneTestVector(
-            disclosed?.invalid?.noProofTypeOrCryptosuite);
-          await verificationFail({credential, verifier});
-        });
-        it('The proof options MUST contain a type identifier for the ' +
-        'cryptographic suite (type) and MAY contain a cryptosuite ' +
-        'identifier (cryptosuite).', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-bbs/#linkage-via-proof-options-and-mandatory-reveal:~:text=The%20proof%20options%20MUST%20contain%20a%20type%20identifier%20for%20the%20cryptographic%20suite%20(type)%20and%20MAY%20contain%20a%20cryptosuite%20identifier%20(cryptosuite).';
           await verificationFail({
             credential: cloneTestVector(
               disclosed?.invalid?.noProofTypeOrCryptosuite),
@@ -128,6 +120,11 @@ export function verifySuite({
           await verificationFail({
             credential: cloneTestVector(
               disclosed?.invalid?.noProofType),
+            verifier
+          });
+          await verificationFail({
+            credential: cloneTestVector(
+              disclosed?.invalid?.noCryptosuite),
             verifier
           });
         });

--- a/tests/vc-generator/generators.js
+++ b/tests/vc-generator/generators.js
@@ -7,12 +7,11 @@ import * as mocks from './mockMethods.js';
 export function noProofTypeorCryptosuite({
   suite,
   selectiveSuite,
+  proofType,
+  cryptosuiteName,
   ...args}) {
-  suite._cryptosuite = _proxyStub({
-    object: suite._cryptosuite,
-    mocks: {createVerifyData: mocks.createVerifyData},
-  });
-  return {...args, suite, selectiveSuite};
+
+  return {...args, suite, selectiveSuite, proofType, cryptosuiteName};
 }
 
 export function invalidStringEncoding({suite, selectiveSuite, ...args}) {

--- a/tests/vc-generator/generators.js
+++ b/tests/vc-generator/generators.js
@@ -7,11 +7,12 @@ import * as mocks from './mockMethods.js';
 export function noProofTypeorCryptosuite({
   suite,
   selectiveSuite,
-  proofType,
-  cryptosuiteName,
   ...args}) {
-
-  return {...args, suite, selectiveSuite, proofType, cryptosuiteName};
+  suite._cryptosuite = _proxyStub({
+    object: suite._cryptosuite,
+    mocks: {createVerifyData: mocks.createVerifyData},
+  });
+  return {...args, suite, selectiveSuite};
 }
 
 export function invalidStringEncoding({suite, selectiveSuite, ...args}) {

--- a/tests/vc-generator/generators.js
+++ b/tests/vc-generator/generators.js
@@ -4,7 +4,7 @@
  */
 import * as mocks from './mockMethods.js';
 
-export function noProofTypeorCryptosuite({
+export function allowUnsafeCanonize({
   suite,
   selectiveSuite,
   ...args}) {


### PR DESCRIPTION
- [x] on removal of proof options from base proof serialization algorithm in bbs spec remove test.
- [x] merge additional test vectors into the single compound MUST have type and cryptosuite