### PR TITLE
(6) Invalid cbor tag

### DIFF
--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -88,9 +88,11 @@ export const checkHmacKeyLength = ({proof, keyLength}) => {
 export const shouldNotUseCborTags = ({proof}) => {
   let error;
   let result;
+  const tags = [];
+  tags[64] = bytes => bytes;
   try {
     // try to parse the base proof with no cbor tags
-    result = parseBaseProofValue({proof, tags: {}});
+    result = parseBaseProofValue({proof, tags});
   } catch(e) {
     error = e;
   }

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -85,6 +85,19 @@ export const checkHmacKeyLength = ({proof, keyLength}) => {
     `Expected hmacKey length to be ${keyLength}. Received: ${hmacKey.length}.`);
 };
 
+export const shouldNotUseCborTags = ({proof}) => {
+  let error;
+  let result;
+  try {
+    // try to parse the base proof with no cbor tags
+    result = parseBaseProofValue({proof, tags: {}});
+  } catch(e) {
+    error = e;
+  }
+  should.not.exist(error, 'Expected proof to decode with out cbor tags.');
+  should.exist(result, 'Expected proof to be decoded.');
+};
+
 export const shouldBeMultibaseEncoded = async ({
   expectedLength,
   prefixes = {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -4,6 +4,7 @@
  */
 import {
   allowUnsafeCanonize,
+  invalidCborEncoding,
   invalidStringEncoding
 } from './vc-generator/generators.js';
 import {
@@ -35,7 +36,9 @@ export async function verifySetup({credentials, keyTypes, suite}) {
       // invalid "proof.cryptosuite"
       cryptosuite: new Map(),
       // for invalid string encoding test
-      nonUTF8: new Map()
+      nonUTF8: new Map(),
+      // invalid cbor encoding
+      cbor: new Map()
     }
   };
   const {subjectNestedObjects, subjectHasArrays} = credentials.verify;
@@ -177,6 +180,12 @@ export async function verifySetup({credentials, keyTypes, suite}) {
     vectors: disclosedBasicVectors,
     suiteName: suite,
     generators: [invalidStringEncoding]
+  });
+  disclosed.invalid.cborg = await deriveCredentials({
+    keys,
+    vectors: disclosedBasicVectors,
+    suiteName: suite,
+    generators: [invalidCborEncoding]
   });
   return {
     base,

--- a/tests/suites/create.js
+++ b/tests/suites/create.js
@@ -8,7 +8,8 @@ import {
   checkHmacKeyLength,
   shouldBeMultibaseEncoded,
   shouldBeProofValue,
-  shouldVerifyDerivedProof
+  shouldVerifyDerivedProof,
+  shouldNotUseCborTags
 } from '../assertions.js';
 import {createInitialVc, getBs58Bytes, supportsVc} from '../helpers.js';
 import chai from 'chai';
@@ -247,6 +248,14 @@ export function createSuite({
               checkHmacKeyLength({proof, keyLength: 32});
             }
           });
+        it('CBOR-encode components per [RFC8949] where CBOR tagging MUST NOT ' +
+        'be used on any of the components. Append the produced encoded value ' +
+        'to proofValue.', function() {
+          this.test.link = 'https://w3c.github.io/vc-di-bbs/#base-proof-transformation-bbs-2023:~:text=and%20signerBlind.-,CBOR%2Dencode%20components%20per%20%5BRFC8949%5D%20where%20CBOR%20tagging%20MUST%20NOT%20be%20used%20on%20any%20of%20the%20components.%20Append%20the%20produced%20encoded%20value%20to%20proofValue.,-Initialize%20baseProof%20to';
+          for(const proof of bbsProofs) {
+            shouldNotUseCborTags({proof});
+          }
+        });
       });
     }
   });

--- a/tests/suites/create.js
+++ b/tests/suites/create.js
@@ -8,8 +8,8 @@ import {
   checkHmacKeyLength,
   shouldBeMultibaseEncoded,
   shouldBeProofValue,
-  shouldVerifyDerivedProof,
-  shouldNotUseCborTags
+  shouldNotUseCborTags,
+  shouldVerifyDerivedProof
 } from '../assertions.js';
 import {createInitialVc, getBs58Bytes, supportsVc} from '../helpers.js';
 import chai from 'chai';

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -119,13 +119,11 @@ export function verifySuite({
             verifier
           });
           await verificationFail({
-            credential: cloneTestVector(
-              disclosed?.invalid?.noProofType),
+            credential: cloneTestVector(disclosed?.invalid?.noProofType),
             verifier
           });
           await verificationFail({
-            credential: cloneTestVector(
-              disclosed?.invalid?.noCryptosuite),
+            credential: cloneTestVector(disclosed?.invalid?.noCryptosuite),
             verifier
           });
         });
@@ -134,8 +132,7 @@ export function verifySuite({
         'to proofValue.', async function() {
           this.test.link = 'https://w3c.github.io/vc-di-bbs/#base-proof-transformation-bbs-2023:~:text=and%20pseudonym.-,CBOR%2Dencode%20components%20per%20%5BRFC8949%5D%20where%20CBOR%20tagging%20MUST%20NOT%20be%20used%20on%20any%20of%20the%20components.%20Append%20the%20produced%20encoded%20value%20to%20proofValue.,-Return%20the%20derived';
           await verificationFail({
-            credential: cloneTestVector(
-              disclosed?.invalid?.cborg),
+            credential: cloneTestVector(disclosed?.invalid?.cborg),
             verifier
           });
         });

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -132,6 +132,7 @@ export function verifySuite({
         it('CBOR-encode components per [RFC8949] where CBOR tagging MUST NOT ' +
         'be used on any of the components. Append the produced encoded value ' +
         'to proofValue.', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-bbs/#base-proof-transformation-bbs-2023:~:text=and%20pseudonym.-,CBOR%2Dencode%20components%20per%20%5BRFC8949%5D%20where%20CBOR%20tagging%20MUST%20NOT%20be%20used%20on%20any%20of%20the%20components.%20Append%20the%20produced%20encoded%20value%20to%20proofValue.,-Return%20the%20derived';
           await verificationFail({
             credential: cloneTestVector(
               disclosed?.invalid?.cborg),

--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -129,6 +129,15 @@ export function verifySuite({
             verifier
           });
         });
+        it('CBOR-encode components per [RFC8949] where CBOR tagging MUST NOT ' +
+        'be used on any of the components. Append the produced encoded value ' +
+        'to proofValue.', async function() {
+          await verificationFail({
+            credential: cloneTestVector(
+              disclosed?.invalid?.cborg),
+            verifier
+          });
+        });
         it('MUST fail to verify a base proof.', async function() {
           const credential = cloneTestVector(base);
           await verificationFail({credential, verifier});

--- a/tests/vc-generator/generators.js
+++ b/tests/vc-generator/generators.js
@@ -20,6 +20,25 @@ export function invalidStringEncoding({suite, selectiveSuite, ...args}) {
   return {...args, suite, selectiveSuite};
 }
 
+export function invalidCborEncoding({suite, ...args}) {
+  suite._cryptosuite = stubMethods({
+    object: suite._cryptosuite,
+    stubs: {createProofValue: stubs.stubProofValue({
+      typeEncoders: {
+        Uint8Array(uint8Array) {
+          console.log('called on unit8Array encoder', uint8Array);
+          return null;
+        },
+        string(str) {
+          console.log('string encoder called', str);
+          return null;
+        }
+      }
+    })}
+  });
+  return {...args, suite};
+}
+
 /**
  * Creates a Proxy which stubs method(s) on an object.
  *

--- a/tests/vc-generator/stubMethods.js
+++ b/tests/vc-generator/stubMethods.js
@@ -25,6 +25,7 @@ const CBOR_PREFIX_DERIVED = new Uint8Array([0xd9, 0x5d, 0x03]);
 // of byte string major type 2
 const TAGS = [];
 TAGS[64] = bytes => bytes;
+TAGS[2] = bytes => bytes.map(b => b - 1);
 
 export function stubProofValue({
   utfOffset = 0,
@@ -331,7 +332,8 @@ export function parseBaseProofValue({proof} = {}) {
 
 export function stubDerive({
   name,
-  utfOffset
+  utfOffset,
+  typeEncoders
 } = {}) {
   const createDisclosureData = stubDisclosureData({utfOffset, name});
   return async function({
@@ -359,8 +361,9 @@ export function stubDerive({
     // create new disclosure proof
     const newProof = {...baseProof};
     newProof.proofValue = await serializeDisclosureProofValue({
-      bbsProof, labelMap, mandatoryIndexes, selectiveIndexes,
-      presentationHeader
+      bbsProof, labelMap,
+      mandatoryIndexes, selectiveIndexes,
+      presentationHeader, typeEncoders
     });
 
     // attach proof to reveal doc w/o context
@@ -371,7 +374,9 @@ export function stubDerive({
 }
 
 function serializeDisclosureProofValue({
-  bbsProof, labelMap, mandatoryIndexes, selectiveIndexes, presentationHeader
+  bbsProof, labelMap,
+  mandatoryIndexes, selectiveIndexes,
+  presentationHeader, typeEncoders
 } = {}) {
   // NOTE: validator is skipped here
 
@@ -389,7 +394,7 @@ function serializeDisclosureProofValue({
     presentationHeader
   ];
   const cbor = concatBuffers([
-    CBOR_PREFIX_DERIVED, cborg.encode(payload, {useMaps: true})
+    CBOR_PREFIX_DERIVED, cborg.encode(payload, {useMaps: true, typeEncoders})
   ]);
   return `u${base64url.encode(cbor)}`;
 }

--- a/tests/vc-generator/stubMethods.js
+++ b/tests/vc-generator/stubMethods.js
@@ -295,7 +295,7 @@ export function stubDisclosureData({
   };
 }
 
-export function parseBaseProofValue({proof} = {}) {
+export function parseBaseProofValue({proof, tags = TAGS} = {}) {
   try {
     if(typeof proof?.proofValue !== 'string') {
       throw new TypeError('"proof.proofValue" must be a string.');
@@ -315,8 +315,7 @@ export function parseBaseProofValue({proof} = {}) {
       publicKey,
       hmacKey,
       mandatoryPointers
-    ] = cborg.decode(payload, {useMaps: true, tags: TAGS});
-
+    ] = cborg.decode(payload, {useMaps: true, tags});
     const params = {
       bbsSignature, bbsHeader, publicKey, hmacKey, mandatoryPointers
     };


### PR DESCRIPTION
Features:

1. Adds support for `typeEncoders` for the cbor encoding
2. Adds a tag for decoding a custom `Uint8Array` encoder.
3. Adds a verifier test derived from a cbor encoded base proof with a invalid cbor encoded disclosed proof.