### PR TITLE
(8) Vm url test

### DIFF
--- a/tests/suites/create.js
+++ b/tests/suites/create.js
@@ -14,6 +14,7 @@ import {
 import {createInitialVc, getBs58Bytes, supportsVc} from '../helpers.js';
 import chai from 'chai';
 import {documentLoader} from '../documentLoader.js';
+import {shouldBeUrl} from 'data-integrity-test-suite-assertion';
 
 const should = chai.should();
 
@@ -153,7 +154,10 @@ export function createSuite({
           function() {
             this.test.link = 'https://w3c.github.io/vc-di-bbs/#:~:text=The%20verificationMethod%20property%20of%20the%20proof%20MUST%20be%20a%20URL';
             for(const proof of bbsProofs) {
-
+              shouldBeUrl({
+                url: proof.verificationMethod,
+                prop: 'proof.verificationMethod'
+              });
             }
           });
         it('Dereferencing "verificationMethod" MUST result in an object ' +

--- a/tests/suites/create.js
+++ b/tests/suites/create.js
@@ -149,9 +149,17 @@ export function createSuite({
             'to match the verification method controller.'
           );
         });
+        it('The verificationMethod property of the proof MUST be a URL.',
+          function() {
+            this.test.link = 'https://w3c.github.io/vc-di-bbs/#:~:text=The%20verificationMethod%20property%20of%20the%20proof%20MUST%20be%20a%20URL';
+            for(const proof of bbsProofs) {
+
+            }
+          });
         it('Dereferencing "verificationMethod" MUST result in an object ' +
           'containing a type property with "Multikey" value.',
         async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-bbs/#:~:text=Dereferencing%20the%20verificationMethod%20MUST%20result%20in%20an%20object%20containing%20a%20type%20property%20with%20the%20value%20set%20to%20Multikey';
           verificationMethodDocuments.should.not.eql([], 'Expected ' +
             'at least one "verificationMethodDocument".');
           verificationMethodDocuments.some(


### PR DESCRIPTION
- Adds one new test that asserts that verificaitonMethod is a url
- Adds `this.test.link` to 1 existing test and 1 new test
- [x] Awaits [Data Integrity `shouldBeUrl` common assertion](https://github.com/w3c-ccg/data-integrity-test-suite-assertion/pull/53).