### PR TITLE
Remove deprecated statement WRT to cryptosuite = bbs-2023.

### DIFF
--- a/tests/suites/verify.js
+++ b/tests/suites/verify.js
@@ -94,11 +94,6 @@ export function verifySuite({
           //FIXME assert on error type in the future
           await verificationFail({credential, verifier});
         });
-        it('If the "cryptosuite" field is not the string "bbs-2023", ' +
-          'an error MUST be raised.', async function() {
-          const credential = cloneTestVector(disclosed?.invalid?.cryptosuite);
-          await verificationFail({credential, verifier});
-        });
         it('If proofConfig.type is not set to DataIntegrityProof and/or ' +
             'proofConfig.cryptosuite is not set to bbs-2023, an error MUST ' +
             'be raised and SHOULD convey an error type of ' +


### PR DESCRIPTION
Removes the deprecated statement: 

> If the "cryptosuite" field is not the string "bbs-2023" an error MUST be raised


source: https://w3c.github.io/vc-di-bbs/
