### PR TITLE
Use name and description attributes instead of vdl

### DIFF
--- a/tests/fixtures/license/1.1/credential.json
+++ b/tests/fixtures/license/1.1/credential.json
@@ -1,19 +1,16 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://w3id.org/vdl/v2"
+    {
+      "name": "https://schema.org/name",
+      "description": "https://schema.org/description"
+    }
   ],
   "id": "urn:uuid:36245ee9-9074-4b05-a777-febff2e69757",
-  "type": ["VerifiableCredential", "Iso18013DriversLicenseCredential"],
+  "type": ["VerifiableCredential"],
   "credentialSubject": {
-    "id": "urn:uuid:1a0e4ef5-091f-4060-842e-18e519ab9440",
-    "type": "LicensedDriver",
-    "driversLicense": {
-      "type": "Iso18013DriversLicense",
-      "document_number": "T21387yc328c7y32h23f23",
-      "birth_date": "01-01-1990",
-      "expiry_date": "01-01-2030",
-      "issuing_authority": "VA"
-    }
+    "id": "did:example:alice",
+    "name": "Alice",
+    "description": "A credential about Alice."
   }
 }

--- a/tests/fixtures/license/1.1/selectivePointers.json
+++ b/tests/fixtures/license/1.1/selectivePointers.json
@@ -1,6 +1,3 @@
 [
-  "/credentialSubject/driversLicense/document_number",
-  "/credentialSubject/driversLicense/birth_date",
-  "/credentialSubject/driversLicense/expiry_date",
-  "/credentialSubject/driversLicense/issuing_authority"
+  "/credentialSubject/name"
 ]

--- a/tests/fixtures/license/2.0/credential.json
+++ b/tests/fixtures/license/2.0/credential.json
@@ -1,19 +1,12 @@
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://w3id.org/vdl/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "urn:uuid:36245ee9-9074-4b05-a777-febff2e69757",
-  "type": ["VerifiableCredential", "Iso18013DriversLicenseCredential"],
+  "type": ["VerifiableCredential"],
   "credentialSubject": {
-    "id": "urn:uuid:1a0e4ef5-091f-4060-842e-18e519ab9440",
-    "type": "LicensedDriver",
-    "driversLicense": {
-      "type": "Iso18013DriversLicense",
-      "document_number": "T21387yc328c7y32h23f23",
-      "birth_date": "01-01-1990",
-      "expiry_date": "01-01-2030",
-      "issuing_authority": "VA"
-    }
+    "id": "did:example:alice",
+    "name": "Alice",
+    "description": "A credential about Alice."
   }
 }

--- a/tests/fixtures/license/2.0/selectivePointers.json
+++ b/tests/fixtures/license/2.0/selectivePointers.json
@@ -1,6 +1,3 @@
 [
-  "/credentialSubject/driversLicense/document_number",
-  "/credentialSubject/driversLicense/birth_date",
-  "/credentialSubject/driversLicense/expiry_date",
-  "/credentialSubject/driversLicense/issuing_authority"
+  "/credentialSubject/name"
 ]


### PR DESCRIPTION
The local verifier is unable to resolve the vdl context, until this is sorted out I suggest to use a simpler credential. The former behavior is causing the test-suite to crash.