### PR TITLE
Use local document loader with vdlCtx

### DIFF
--- a/tests/15-di-bbs-verify.js
+++ b/tests/15-di-bbs-verify.js
@@ -7,6 +7,7 @@ import * as bbs2023Cryptosuite from '@digitalbazaar/bbs-2023-cryptosuite';
 import {
   checkDataIntegrityProofVerifyErrors
 } from 'data-integrity-test-suite-assertion';
+import {documentLoader} from './vc-generator/documentLoader.js';
 import {endpoints} from 'vc-test-suite-implementations';
 import {filterVerifiers} from './helpers.js';
 import {getMultiKey} from './vc-generator/key-gen.js';
@@ -30,6 +31,7 @@ for(const vcVersion of vectors.vcTypes) {
       authentication: true
     },
     testDataOptions: {
+      documentLoader,
       suiteName: 'bbs-2023',
       key,
       cryptosuite: bbs2023Cryptosuite,

--- a/tests/vc-generator/contexts.js
+++ b/tests/vc-generator/contexts.js
@@ -14,27 +14,42 @@ import dataIntegrityCtx from '@digitalbazaar/data-integrity-context';
 import didCtx from '@digitalcredentials/did-context';
 import multikeyCtx from '@digitalbazaar/multikey-context';
 
-const contextMap = new Map(credentialsContexts);
+const contextMap = new Map();
 const setContexts = contexts => {
   for(const [key, value] of contexts) {
     contextMap.set(key, structuredClone(value));
   }
 };
+const invalidPurpose = {
+  '@id': 'https://w3id.org/security#invalidPurpose',
+  '@type': '@id',
+  '@container': '@set'
+};
 
-const {context: vc2Context} = namedCredentialsContexts.get('v2');
-const v2Ctx = vc2Context['@context'];
+// adding terms manually
+const {
+  id: v2ContextUrl,
+  context: v2Context
+} = structuredClone(namedCredentialsContexts.get('v2'));
+const v2Ctx = v2Context['@context'];
 v2Ctx.UnknownProofType = structuredClone(v2Ctx.DataIntegrityProof);
+v2Ctx.DataIntegrityProof['@context'].proofPurpose['@context'].invalidPurpose =
+  invalidPurpose;
+v2Ctx.undefinedTerm = 'urn:example:undefinedTerm';
+
 const _dataIntegrityCtx = structuredClone(dataIntegrityCtx.CONTEXT);
 const diCtx = _dataIntegrityCtx['@context'];
 diCtx.UnknownProofType = structuredClone(diCtx.DataIntegrityProof);
-contextMap.set(
-  dataIntegrityCtx.constants.CONTEXT_URL,
-  _dataIntegrityCtx
-);
-// add contexts for the documentLoader
+diCtx.DataIntegrityProof['@context'].proofPurpose['@context'].invalidPurpose =
+  invalidPurpose;
+diCtx.undefinedTerm = 'urn:example:undefinedTerm';
+
+// adding to contextMap
+setContexts(didCtx.contexts);
+setContexts(credentialsContexts);
 contextMap.set(multikeyCtx.constants.CONTEXT_URL, multikeyCtx.CONTEXT);
 contextMap.set(vdlCtxUrl, vdlCtx);
-// add the dids contexts
-setContexts(didCtx.contexts);
+contextMap.set(dataIntegrityCtx.constants.CONTEXT_URL, _dataIntegrityCtx);
+contextMap.set(v2ContextUrl, v2Context);
 
 export {contextMap};


### PR DESCRIPTION
Data Integrity bbs-2023 verifiers test case uses vdl context, which is not present in `defaultLoader` used by `issueCloned` (from data-integrity-test-suite repo) - this leads to test case `before` hook failing. So instead using local `documentLoader` which has vdlCtx cached.  Updated `contexts.js` with required contexts.

Related PRs:
- https://github.com/w3c/vc-di-bbs-test-suite/pull/71
- https://github.com/w3c/vc-di-bbs-test-suite/pull/73